### PR TITLE
サーバー構築 - 8回目の授業 -

### DIFF
--- a/06/db-deployment.yaml
+++ b/06/db-deployment.yaml
@@ -22,11 +22,11 @@ spec:
               name: wordpress-secret
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "250m"
+            memory: "372Mi"
+            cpu: "100m"
           limits:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "1280Mi"
+            cpu: "300m"
         volumeMounts:
         - name: db-data-storage
           mountPath: /var/lib/mysql

--- a/06/wp-deployment.yaml
+++ b/06/wp-deployment.yaml
@@ -23,10 +23,10 @@ spec:
         resources:
           requests:
             memory: "256Mi"
-            cpu: "250m"
+            cpu: "350m"
           limits:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "768Mi"
+            cpu: "1050m"
         volumeMounts:
         - name: wp-data-storage
           mountPath: /var/www/html

--- a/06/作業ログ_08.md
+++ b/06/作業ログ_08.md
@@ -1,0 +1,40 @@
+## 8回目の授業
+
+### (課題) k8s の deployment に設定した resources の値を見直す
+
+```bash
+1. wordpress をデプロイできているかの確認
+
+# k8s クラスタに接続できることを確認する
+# 疎通出来ない場合は以下のコマンドでで立ち上げる
+kind create cluster --config cluster.yaml 
+
+# 上手くいかない場合は以下のコマンドで一度消しても良い
+kind delete cluster
+
+# manifest の内容でデプロイされる
+kustomize build . |kubectl apply -f - 
+```
+
+```bash
+2. k8s で Pod の負荷が確認できるようにしつつ wordpress に一定の負荷を掛ける
+
+# kind で pod のリソースが確認できるようにするために metrics-server をデプロイ
+kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml
+
+# wordpress にアクセスできるように port-fowward する
+kubectl port-forward service/wordpress 8080:8080 > /dev/null
+
+# 新しい vscode の terminal のタブで curl を使って負荷を掛ける。 localhost (自分のPC)じゃない別のサーバーに負荷を掛けないように注意する
+while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done 
+```
+
+```bash
+3. k8s の deployment に設定した resources の値を見直す
+
+(ポイント) 
+
+・requests には実際の値の1.5倍くらいの値を切り上げしてキリの良い数値で記載すると良い
+
+・limits は requests の3倍くらい
+```


### PR DESCRIPTION
## なぜやるか

- k8s の deployment に設定した resources の値を見直す

## なにをやったのか

1. wordpress をデプロイできているかの確認
2. k8s で Pod の負荷が確認できるようにしつつ wordpress に一定の負荷を掛ける
3. k8s の deployment に設定した resources の値を見直す

## 動作確認の手順

```
# kind で pod のリソースが確認できるようにするために metrics-server をデプロイ
kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml

# wordpress にアクセスできるように port-fowward する
kubectl port-forward service/wordpress 8080:8080 > /dev/null

# 新しい vscode の terminal のタブで curl を使って負荷を掛ける。 localhost (自分のPC)じゃない別のサーバーに負荷を掛けないように注意する
while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done 

# 以下のコマンドでメモリ使用量を確認
kubectl top pods
```

## スクリーンショット

<img width="524" height="55" alt="スクリーンショット 2025-07-23 18 28 10" src="https://github.com/user-attachments/assets/6bc8d872-52f4-43d0-a210-ae5f74e62bd5" />
